### PR TITLE
#27 - Use ConfigFiles in page implementations

### DIFF
--- a/src/main/java/com/artipie/management/ConfigFiles.java
+++ b/src/main/java/com/artipie/management/ConfigFiles.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletionStage;
  * files `name.yaml` and `name.yml` are searched.
  * @since 0.4
  */
-public interface ConfigFile {
+public interface ConfigFiles {
 
     /**
      * Does specified config file exist in the storage?

--- a/src/main/java/com/artipie/management/api/ApiRepoGetSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoGetSlice.java
@@ -34,7 +34,7 @@ import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
@@ -57,13 +57,13 @@ public final class ApiRepoGetSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * New repo API.
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public ApiRepoGetSlice(final ConfigFile configfile) {
+    public ApiRepoGetSlice(final ConfigFiles configfile) {
         this.configfile = configfile;
     }
 

--- a/src/main/java/com/artipie/management/api/ApiRepoListSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoListSlice.java
@@ -32,7 +32,7 @@ import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.common.RsJson;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -62,14 +62,14 @@ public final class ApiRepoListSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * New repo list API.
      * @param storage Artipie settings storage
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public ApiRepoListSlice(final Storage storage, final ConfigFile configfile) {
+    public ApiRepoListSlice(final Storage storage, final ConfigFiles configfile) {
         this.storage = storage;
         this.configfile = configfile;
     }

--- a/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
@@ -39,7 +39,7 @@ import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
@@ -77,13 +77,13 @@ public final class ApiRepoUpdateSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * New patch API.
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public ApiRepoUpdateSlice(final ConfigFile configfile) {
+    public ApiRepoUpdateSlice(final ConfigFiles configfile) {
         this.configfile = configfile;
     }
 

--- a/src/main/java/com/artipie/management/api/artifactory/CreateRepoSlice.java
+++ b/src/main/java/com/artipie/management/api/artifactory/CreateRepoSlice.java
@@ -34,7 +34,7 @@ import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import com.artipie.management.api.ContentAsJson;
 import io.reactivex.Single;
 import java.nio.ByteBuffer;
@@ -70,14 +70,14 @@ public final class CreateRepoSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * Ctor.
      * @param storage Artipie settings storage
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public CreateRepoSlice(final Storage storage, final ConfigFile configfile) {
+    public CreateRepoSlice(final Storage storage, final ConfigFiles configfile) {
         this.storage = storage;
         this.configfile = configfile;
     }

--- a/src/main/java/com/artipie/management/api/artifactory/DeletePermissionSlice.java
+++ b/src/main/java/com/artipie/management/api/artifactory/DeletePermissionSlice.java
@@ -31,7 +31,7 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import com.artipie.management.RepoPermissions;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -56,14 +56,14 @@ public final class DeletePermissionSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * Ctor.
      * @param permissions Artipie repository permissions
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public DeletePermissionSlice(final RepoPermissions permissions, final ConfigFile configfile) {
+    public DeletePermissionSlice(final RepoPermissions permissions, final ConfigFiles configfile) {
         this.permissions = permissions;
         this.configfile = configfile;
     }

--- a/src/main/java/com/artipie/management/api/artifactory/GetPermissionSlice.java
+++ b/src/main/java/com/artipie/management/api/artifactory/GetPermissionSlice.java
@@ -31,7 +31,7 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
 import com.artipie.http.rs.common.RsJson;
-import com.artipie.management.ConfigFile;
+import com.artipie.management.ConfigFiles;
 import com.artipie.management.RepoPermissions;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -63,14 +63,14 @@ public final class GetPermissionSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
-    private final ConfigFile configfile;
+    private final ConfigFiles configfile;
 
     /**
      * Ctor.
      * @param permissions Repository permissions
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public GetPermissionSlice(final RepoPermissions permissions, final ConfigFile configfile) {
+    public GetPermissionSlice(final RepoPermissions permissions, final ConfigFiles configfile) {
         this.permissions = permissions;
         this.configfile = configfile;
     }

--- a/src/main/java/com/artipie/management/dashboard/UserPage.java
+++ b/src/main/java/com/artipie/management/dashboard/UserPage.java
@@ -27,6 +27,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.management.ConfigFiles;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import io.reactivex.Single;
@@ -60,13 +61,20 @@ public final class UserPage implements Page {
     private final Storage storage;
 
     /**
+     * Config file to support `yaml` and `.yml` extensions.
+     */
+    private final ConfigFiles configfile;
+
+    /**
      * New page.
      * @param tpl Template loader
      * @param storage Settings storage
+     * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public UserPage(final TemplateLoader tpl, final Storage storage) {
+    public UserPage(final TemplateLoader tpl, final Storage storage, final ConfigFiles configfile) {
         this.handlebars = new Handlebars(tpl);
         this.storage = storage;
+        this.configfile = configfile;
     }
 
     @Override
@@ -86,7 +94,7 @@ public final class UserPage implements Page {
                         new MapEntry<>(
                             "repos",
                             repos.stream()
-                                .map(key -> key.string().replace(".yaml", ""))
+                                .map(this.configfile::name)
                                 .collect(Collectors.toList())
                         )
                     )

--- a/src/test/java/com/artipie/management/FakeConfigFile.java
+++ b/src/test/java/com/artipie/management/FakeConfigFile.java
@@ -33,11 +33,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Fake {@link ConfigFile} implementation.
+ * Fake {@link ConfigFiles} implementation.
  * @since 0.4
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class FakeConfigFile implements ConfigFile {
+public final class FakeConfigFile implements ConfigFiles {
 
     /**
      * Pattern to divide `yaml` or `yml` filename into two groups: name and extension.


### PR DESCRIPTION
Closes #27 
Renamed `ConfigFile` to `ConfigFiles` to avoid identical names in `artipie` module. Use `ConfigFiles` in page implementations.