### PR TITLE
#27 - Revert using ContentAs in ApiRepoGetSlice

### DIFF
--- a/src/main/java/com/artipie/management/api/ApiRepoGetSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoGetSlice.java
@@ -66,7 +66,7 @@ public final class ApiRepoGetSlice implements Slice {
      * New repo API.
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    ApiRepoGetSlice(final ConfigFiles configfile) {
+    public ApiRepoGetSlice(final ConfigFiles configfile) {
         this.configfile = configfile;
     }
 


### PR DESCRIPTION
Part of #27 
Reverted using `ContentAs` in `ApiRepoGetSlice` because github actions in `artipie` module hung up.