### PR TITLE
Fixed parsing error in `ApiRepoUpdateSlice`

### DIFF
--- a/src/test/java/com/artipie/management/api/ApiRepoUpdateSliceTest.java
+++ b/src/test/java/com/artipie/management/api/ApiRepoUpdateSliceTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -32,7 +31,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-@Disabled
 final class ApiRepoUpdateSliceTest {
 
     /**


### PR DESCRIPTION
Closes #35 and #31 
Fixed `ApiRepoUpdateSlice`, there was a problem with loosing line breaks during parsing (`URLEncodedUtils` does not handle spaces properly).