### PR TITLE
Improved updating storage settings functionality

### DIFF
--- a/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
@@ -21,13 +21,11 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.management.ConfigFiles;
-import hu.akarnokd.rxjava2.interop.SingleInterop;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.cactoos.scalar.Unchecked;
@@ -88,59 +86,34 @@ public final class ApiRepoUpdateSlice implements Slice {
                         ).value();
                         return this.configfile.exists(key).thenCompose(
                             exist -> {
-                                final CompletionStage<YamlMapping> res;
-                                if (exist) {
-                                    res = SingleInterop.fromFuture(this.configfile.value(key)).to(new ContentAsYaml()).map(
-                                        source -> {
-                                            final YamlMapping patch = config.yamlMapping("repo");
-                                            YamlMappingBuilder repo = Yaml.createYamlMappingBuilder();
-                                            repo = repo.add("type", source.yamlMapping("repo").value("type"));
-                                            if (patch.value("type") != null) {
-                                                repo = repo.add("type", patch.value("type"));
-                                            }
-                                            repo = repo.add("storage", source.yamlMapping("repo").value("storage"));
-                                            if (patch.value("storage") != null && Scalar.class.isAssignableFrom(patch.value("storage").getClass())) {
-                                                repo = repo.add("storage", patch.value("storage"));
-                                            }
-                                            repo = repo.add("permissions", source.yamlMapping("repo").value("permissions"));
-                                            if (patch.value("permissions") != null) {
-                                                repo = repo.add("permissions", patch.value("permissions"));
-                                            }
-                                            repo = repo.add("settings", source.yamlMapping("repo").value("settings"));
-                                            if (patch.value("permissions") != null) {
-                                                repo = repo.add("settings", patch.value("settings"));
-                                            }
-                                            return Yaml.createYamlMappingBuilder()
-                                                .add("repo", repo.build())
-                                                .build();
-                                        }
-                                    ).to(SingleInterop.get());
-                                } else {
-                                    final YamlMapping repo = config.yamlMapping("repo");
-                                    final YamlNode type = repo.value("type");
-                                    if (type == null || !Scalar.class.isAssignableFrom(type.getClass())) {
-                                        throw new IllegalStateException("Repository type required");
-                                    }
-                                    final YamlMapping ystor = repo.yamlMapping("storage");
-                                    final String sstor = repo.string("storage");
-                                    if (ystor == null && sstor == null) {
-                                        throw new IllegalStateException("Repository storage is required");
-                                    }
-                                    YamlMappingBuilder yrepo = Yaml.createYamlMappingBuilder()
-                                        .add("type", type)
-                                        .add("permissions", repo.value("permissions"));
-                                    if (ystor == null) {
-                                        yrepo = yrepo.add("storage", sstor);
-                                    } else {
-                                        yrepo = yrepo.add("storage", ystor);
-                                    }
-                                    res = CompletableFuture.completedFuture(
-                                        Yaml.createYamlMappingBuilder().add(
-                                            "repo", yrepo.build()
-                                        ).build()
-                                    );
+                                final YamlMapping repo = config.yamlMapping("repo");
+                                final YamlNode type = repo.value("type");
+                                if (type == null || !Scalar.class.isAssignableFrom(type.getClass())) {
+                                    throw new IllegalStateException("Repository type required");
                                 }
-                                return res;
+                                final YamlMapping ystor = repo.yamlMapping("storage");
+                                final String sstor = repo.string("storage");
+                                if (ystor == null && sstor == null) {
+                                    throw new IllegalStateException("Repository storage is required");
+                                }
+                                YamlMappingBuilder yrepo = Yaml.createYamlMappingBuilder()
+                                    .add("type", type);
+                                if (ystor == null) {
+                                    yrepo = yrepo.add("storage", sstor);
+                                } else {
+                                    yrepo = yrepo.add("storage", ystor);
+                                }
+                                if (repo.value("permissions") != null) {
+                                    yrepo = yrepo.add("permissions", repo.value("permissions"));
+                                }
+                                if (repo.value("settings") != null) {
+                                    yrepo = yrepo.add("settings", repo.value("settings"));
+                                }
+                                return CompletableFuture.completedFuture(
+                                    Yaml.createYamlMappingBuilder().add(
+                                        "repo", yrepo.build()
+                                    ).build()
+                                );
                             }
                         ).thenCompose(yaml -> this.configfile.save(key, new Content.From(yaml.toString().getBytes(StandardCharsets.UTF_8))))
                         .thenApply(


### PR DESCRIPTION
Closes #42 
I've simplified and fixed updating storage scenario in `ApiRepoUpdateSlice`. 

On dashboard we always work with whole yaml repo settings, so there is no need to update section by section, we can simply rewrite the whole file after checking that required fields (type and storage) are present in the new version.