### PR TITLE
feat: added slice for repo delete

### DIFF
--- a/.pdd
+++ b/.pdd
@@ -3,6 +3,7 @@
 --exclude logo.png
 --exclude target/**/*
 --exclude src/main/resources/images/**/*
+--exclude src/test/resources/**/*
 --exclude .idea/**/*
 --exclude examples/**/*
 --rule min-words:20

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@ SOFTWARE.
       <plugin>
         <groupId>com.qulice</groupId>
         <artifactId>qulice-maven-plugin</artifactId>
+        <version>0.19.0</version>
         <configuration>
           <excludes combine.children="append">
             <exclude>checkstyle:.*/src/test/resources/.*</exclude>

--- a/src/main/java/com/artipie/management/ConfigFiles.java
+++ b/src/main/java/com/artipie/management/ConfigFiles.java
@@ -34,6 +34,13 @@ public interface ConfigFiles {
     CompletionStage<Content> value(Key filename);
 
     /**
+     * Removes value from storage. Fails if value does not exist.
+     * @param filename Filename
+     * @return Result of completion.
+     */
+    CompletionStage<Void> delete(Key filename);
+
+    /**
      * Saves the bytes to the specified key.
      *
      * @param key The key

--- a/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
@@ -32,12 +32,12 @@ import org.reactivestreams.Publisher;
 /**
  * Repo {@code DELETE} API.
  * @since 0.5
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @todo #321:30min Remove code duplication.
  *  In this class and in the class with tests for this one
  *  a pair of very similar utils methods are used which
  *  are also used in classes for update repo. It is necessary
  *  to eliminate this code duplication.
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class ApiRepoDeleteSlice implements Slice {
     /**
@@ -148,6 +148,7 @@ public final class ApiRepoDeleteSlice implements Slice {
      * @param payload Payload to parse
      * @param name Parameter name to obtain
      * @return Parameter value
+     * @checkstyle StringLiteralsConcatenationCheck (10 lines)
      */
     private static String value(final String payload, final String name) {
         final int start = payload.indexOf(String.format("%s=", name)) + name.length() + 1;

--- a/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
@@ -4,7 +4,6 @@
  */
 package com.artipie.management.api;
 
-import com.artipie.ArtipieException;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
@@ -74,7 +73,7 @@ public final class ApiRepoDeleteSlice implements Slice {
     ) {
         final Matcher matcher = PTN.matcher(new RequestLineFrom(line).uri().getPath());
         if (!matcher.matches()) {
-            throw new ArtipieException(
+            throw new IllegalStateException(
                 String.format(
                     "Uri '%s' does not match to the pattern '%s'", line, ApiRepoDeleteSlice.PTN
                 )

--- a/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
@@ -1,0 +1,160 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/management-api/LICENSE.txt
+ */
+package com.artipie.management.api;
+
+import com.artipie.ArtipieException;
+import com.artipie.asto.FailedCompletionStage;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithHeaders;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.management.ConfigFiles;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.reactivestreams.Publisher;
+
+/**
+ * Repo {@code DELETE} API.
+ * @since 0.5
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #321:30min Remove code duplication.
+ *  In this class and in the class with tests for this one
+ *  a pair of very similar utils methods are used which
+ *  are also used in classes for update repo. It is necessary
+ *  to eliminate this code duplication.
+ */
+public final class ApiRepoDeleteSlice implements Slice {
+    /**
+     * URI path pattern.
+     */
+    private static final Pattern PTN = Pattern.compile(
+        "/api/repos/(?<user>[^/?.]+)\\?method=delete$"
+    );
+
+    /**
+     * Config file to support `yaml` and `.yml` extensions.
+     */
+    private final ConfigFiles configfile;
+
+    /**
+     * Storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Ctor.
+     * @param storage Storage
+     * @param configfile Config file to support `yaml` and `.yml` extensions
+     */
+    public ApiRepoDeleteSlice(final Storage storage, final ConfigFiles configfile) {
+        this.storage = storage;
+        this.configfile = configfile;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        final Matcher matcher = PTN.matcher(new RequestLineFrom(line).uri().getPath());
+        if (!matcher.matches()) {
+            throw new ArtipieException(
+                String.format(
+                    "Uri '%s' does not match to the pattern '%s'", line, ApiRepoDeleteSlice.PTN
+                )
+            );
+        }
+        final String user = matcher.group("user");
+        return new AsyncResponse(
+            new PublisherAs(body).asciiString()
+                .thenApply(form -> URLDecoder.decode(form, StandardCharsets.US_ASCII)).thenCompose(
+                    form -> {
+                        final String name = ApiRepoDeleteSlice.value(form, "repo");
+                        final Key repo = new Key.From(user, String.format("%s.yaml", name));
+                        return this.configfile.exists(repo)
+                            .thenCompose(
+                                exists -> {
+                                    final CompletionStage<Void> res;
+                                    if (exists) {
+                                        res = this.configfile.delete(repo)
+                                            .thenCompose(
+                                                noth -> this.storage.list(
+                                                    new Key.From(user, name)
+                                                ).thenCompose(
+                                                    keys -> CompletableFuture.allOf(
+                                                        keys.stream().map(
+                                                            this.storage::delete
+                                                        ).toArray(CompletableFuture[]::new)
+                                                    )
+                                                )
+                                            );
+                                    } else {
+                                        res = new FailedCompletionStage<>(
+                                            new ArtipieException(
+                                                String.format(
+                                                    "Repo '%s' does not exist", repo.string()
+                                                )
+                                            )
+                                        );
+                                    }
+                                    return res;
+                                }
+                            ).thenApply(nothing -> repo);
+                    }).handle(
+                        (repo, thr) -> {
+                            final Response res;
+                            if (thr == null) {
+                                res = new RsWithHeaders(
+                                    new RsWithStatus(RsStatus.OK),
+                                    new Headers.From(
+                                        "Location", String.format("/dashboard/%s", user)
+                                    )
+                                );
+                            } else if (thr.getCause() instanceof ArtipieException) {
+                                res = new RsWithBody(
+                                    new RsWithStatus(RsStatus.BAD_REQUEST),
+                                    String.format("Failed to delete repo '%s'", repo),
+                                    StandardCharsets.UTF_8
+                                );
+                            } else {
+                                res = new RsWithStatus(RsStatus.INTERNAL_ERROR);
+                            }
+                            return res;
+                        }
+                )
+        );
+    }
+
+    /**
+     * Obtain value from payload, payload is a query string (not url-encoded):
+     * <code>name1=value1&name2=value2</code>.
+     * @param payload Payload to parse
+     * @param name Parameter name to obtain
+     * @return Parameter value
+     */
+    private static String value(final String payload, final String name) {
+        final int start = payload.indexOf(String.format("%s=", name)) + name.length() + 1;
+        int end = payload.indexOf('&', start);
+        if (end == -1) {
+            end = payload.length();
+        }
+        return payload.substring(start, end);
+    }
+}

--- a/src/main/resources/dashboard/repo.hbs
+++ b/src/main/resources/dashboard/repo.hbs
@@ -39,6 +39,13 @@ repo:
   </fieldset>
 </form>
 
+<form id="repo-delete-form" action="/api/repos/{{user}}?method=delete" method="POST">
+    <fieldset>
+        <input name="repo" type="hidden" value="{{name}}"/>
+        <input id="repo-delete" type="submit" value="Delete"/>
+    </fieldset>
+</form>
+
 {{#eq type "maven"}}
 <p>With this confirmation,
 the GitHub user <a href="https://github.com/{{user}}"><code>@{{user}}</code></a>

--- a/src/main/resources/dashboard/user.hbs
+++ b/src/main/resources/dashboard/user.hbs
@@ -17,10 +17,20 @@ your username is <code>github.com/{{user}}</code>.</p>
     <option value="maven">Maven</option>
     <option value="file">Binary</option>
     <option value="docker">Docker</option>
+    <option value="pypi">Python</option>
     <option value="npm">NPM</option>
     <option value="rpm">RPM</option>
+    <option value="gem">Gem</option>
+    <option value="helm">Helm</option>
+    <option value="php">PHP</option>
+    <option value="nuget">Debian</option>
+    <option value="deb">Nuget</option>
+    <option value="go">Go</option>
     <option value="maven-proxy">Maven proxy (mirror)</option>
     <option value="file-proxy">Binary proxy (mirror)</option>
+    <option value="npm-proxy">NPM proxy (mirror)</option>
+    <option value="pypi-proxy">Python proxy (mirror)</option>
+    <option value="php-proxy">Php proxy (remote)</option>
     <option value="maven-group">Maven group (virtual)</option>
   </select>
   <input id="new-repo-submit" type="submit" value="Add"/>

--- a/src/test/java/com/artipie/management/FakeConfigFile.java
+++ b/src/test/java/com/artipie/management/FakeConfigFile.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Fake {@link ConfigFiles} implementation.
@@ -85,6 +86,11 @@ public final class FakeConfigFile implements ConfigFiles {
                     return result;
                 }
             );
+    }
+
+    @Override
+    public CompletionStage<Void> delete(final Key filename) {
+        throw new NotImplementedException("not implemented yet");
     }
 
     @Override

--- a/src/test/java/com/artipie/management/api/ApiRepoDeleteSliceTest.java
+++ b/src/test/java/com/artipie/management/api/ApiRepoDeleteSliceTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/management-api/LICENSE.txt
+ */
+package com.artipie.management.api;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import com.artipie.http.Headers;
+import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.management.FakeConfigFile;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link ApiRepoDeleteSlice}.
+ * @since 0.5
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@Disabled
+final class ApiRepoDeleteSliceTest {
+
+    /**
+     * Storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"bin.yaml, bin.yml"})
+    void deletesRepoConfig(final String config) {
+        final String user = "bob";
+        new TestResource(config).saveTo(this.storage, new Key.From(user, config));
+        MatcherAssert.assertThat(
+            "Repo config was not removed",
+            new ApiRepoDeleteSlice(this.storage, new FakeConfigFile(this.storage)),
+            new SliceHasResponse(
+                Matchers.allOf(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasHeaders(
+                        new Headers.From(
+                        "Location", String.format("/dashboard/%s", user)
+                        )
+                    )
+                ),
+                new RequestLine(
+                    RqMethod.POST, String.format("/api/repos/%s?method=delete", user)
+                ),
+                Headers.EMPTY,
+                ApiRepoDeleteSliceTest.body("bin")
+            )
+        );
+        MatcherAssert.assertThat(
+            "Config file was not removed",
+            this.storage.list(Key.ROOT).join(),
+            new IsEmptyCollection<>()
+        );
+    }
+
+    private static Content body(final String reponame) {
+        return new Content.From(
+            URLEncoder.encode(
+                String.format("repo=%s", reponame),
+                StandardCharsets.US_ASCII
+            ).getBytes()
+        );
+    }
+
+}

--- a/src/test/resources/bin.yml
+++ b/src/test/resources/bin.yml
@@ -1,0 +1,5 @@
+repo:
+  type: file
+  storage:
+    type: fs
+    path: /var/path/data/


### PR DESCRIPTION
Part of artipie/artipie#321
Added slice to delete a repo. Added disabled test for this slice as it is necessary to implement `delete` operation in `FakeConfigFile`  class.