### PR TITLE
feat: add slice for routing `POST` requests

### DIFF
--- a/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoDeleteSlice.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
 
 /**
@@ -37,14 +36,7 @@ import org.reactivestreams.Publisher;
  *  to eliminate this code duplication.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class ApiRepoDeleteSlice implements Slice {
-    /**
-     * URI path pattern.
-     */
-    private static final Pattern PTN = Pattern.compile(
-        "/api/repos/(?<user>[^/?.]+)\\?method=delete$"
-    );
-
+final class ApiRepoDeleteSlice implements Slice {
     /**
      * Config file to support `.yaml` and `.yml` extensions.
      */
@@ -60,7 +52,7 @@ public final class ApiRepoDeleteSlice implements Slice {
      * @param storage Storage
      * @param configfile Config file to support `.yaml` and `.yml` extensions
      */
-    public ApiRepoDeleteSlice(final Storage storage, final ConfigFiles configfile) {
+    ApiRepoDeleteSlice(final Storage storage, final ConfigFiles configfile) {
         this.storage = storage;
         this.configfile = configfile;
     }
@@ -71,11 +63,15 @@ public final class ApiRepoDeleteSlice implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body
     ) {
-        final Matcher matcher = PTN.matcher(new RequestLineFrom(line).uri().getPath());
+        final Matcher matcher = ApiRepoPostRtSlice.PTN.matcher(
+            new RequestLineFrom(line).uri().getPath()
+        );
         if (!matcher.matches()) {
             throw new IllegalStateException(
                 String.format(
-                    "Uri '%s' does not match to the pattern '%s'", line, ApiRepoDeleteSlice.PTN
+                    "Uri '%s' does not match to the pattern '%s'",
+                    line,
+                    ApiRepoPostRtSlice.PTN
                 )
             );
         }

--- a/src/main/java/com/artipie/management/api/ApiRepoPostRtSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoPostRtSlice.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/management-api/LICENSE.txt
+ */
+package com.artipie.management.api;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.StandardRs;
+import com.artipie.management.ConfigFiles;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice for routing {@code POST} requests by parsing content and checking
+ * methods which are written in this content.
+ * @since 0.5
+ */
+public final class ApiRepoPostRtSlice implements Slice {
+    /**
+     * URI path pattern.
+     */
+    static final Pattern PTN = Pattern.compile("/api/repos/(?<user>[^/.]+)");
+
+    /**
+     * Config file to support `.yaml` and `.yml` extensions.
+     */
+    private final ConfigFiles configfile;
+
+    /**
+     * Storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Ctor.
+     * @param storage Storage
+     * @param configfile Config file to support `.yaml` and `.yml` extensions
+     */
+    public ApiRepoPostRtSlice(final Storage storage, final ConfigFiles configfile) {
+        this.storage = storage;
+        this.configfile = configfile;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> content
+    ) {
+        return new AsyncResponse(
+            new PublisherAs(content)
+                .asciiString()
+                .thenApply(form -> URLDecoder.decode(form, StandardCharsets.US_ASCII))
+                .thenApply(
+                    form -> {
+                        final Response res;
+                        final String method = ApiRepoPostRtSlice.value(form, "method");
+                        if (Method.UPDATE.value().equals(method)) {
+                            res = new ApiRepoUpdateSlice(this.configfile)
+                                .response(
+                                    line,
+                                    headers,
+                                    new Content.From(form.getBytes(StandardCharsets.US_ASCII))
+                                );
+                        } else if (Method.DELETE.value().equals(method)) {
+                            res = new ApiRepoDeleteSlice(this.storage, this.configfile)
+                                .response(
+                                    line,
+                                    headers,
+                                    new Content.From(form.getBytes(StandardCharsets.US_ASCII))
+                                );
+                        } else {
+                            res = StandardRs.NOT_FOUND;
+                        }
+                        return res;
+                    }
+                )
+        );
+    }
+
+    /**
+     * Type of method of request.
+     * @since 0.5
+     */
+    private enum Method {
+        /**
+         * Update method.
+         */
+        UPDATE("update"),
+        /**
+         * Delete method.
+         */
+        DELETE("delete");
+
+        /**
+         * String value.
+         */
+        private final String name;
+
+        /**
+         * Ctor.
+         * @param name String value
+         */
+        Method(final String name) {
+            this.name = name;
+        }
+
+        /**
+         * Method string.
+         * @return Method string.
+         */
+        public String value() {
+            return this.name;
+        }
+    }
+
+    /**
+     * Obtain value from payload, payload is a query string (not url-encoded):
+     * <code>name1=value1&name2=value2</code>.
+     * @param payload Payload to parse
+     * @param name Parameter name to obtain
+     * @return Parameter value
+     * @checkstyle StringLiteralsConcatenationCheck (10 lines)
+     */
+    private static String value(final String payload, final String name) {
+        final int start = payload.indexOf(String.format("%s=", name)) + name.length() + 1;
+        int end = payload.indexOf('&', start);
+        if (end == -1) {
+            end = payload.length();
+        }
+        return payload.substring(start, end);
+    }
+}

--- a/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
+++ b/src/main/java/com/artipie/management/api/ApiRepoUpdateSlice.java
@@ -28,7 +28,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.cactoos.scalar.Unchecked;
 import org.reactivestreams.Publisher;
 
@@ -40,13 +39,7 @@ import org.reactivestreams.Publisher;
  * @checkstyle CyclomaticComplexityCheck (500 lines)
  * @checkstyle NPathComplexityCheck (500 lines)
  */
-public final class ApiRepoUpdateSlice implements Slice {
-
-    /**
-     * URI path pattern.
-     */
-    private static final Pattern PTN = Pattern.compile("/api/repos/(?<user>[^/.]+)");
-
+final class ApiRepoUpdateSlice implements Slice {
     /**
      * Config file to support `yaml` and `.yml` extensions.
      */
@@ -56,7 +49,7 @@ public final class ApiRepoUpdateSlice implements Slice {
      * New patch API.
      * @param configfile Config file to support `yaml` and `.yml` extensions
      */
-    public ApiRepoUpdateSlice(final ConfigFiles configfile) {
+    ApiRepoUpdateSlice(final ConfigFiles configfile) {
         this.configfile = configfile;
     }
 
@@ -64,7 +57,9 @@ public final class ApiRepoUpdateSlice implements Slice {
     @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.NPathComplexity"})
     public Response response(final String line,
         final Iterable<Map.Entry<String, String>> headers, final Publisher<ByteBuffer> body) {
-        final Matcher matcher = PTN.matcher(new RequestLineFrom(line).uri().getPath());
+        final Matcher matcher = ApiRepoPostRtSlice.PTN.matcher(
+            new RequestLineFrom(line).uri().getPath()
+        );
         if (!matcher.matches()) {
             throw new IllegalStateException("Should match");
         }

--- a/src/main/resources/dashboard/repo.hbs
+++ b/src/main/resources/dashboard/repo.hbs
@@ -35,6 +35,7 @@ repo:
       - download
 {{/if}}</textarea>
     <input name="repo" type="hidden" value="{{name}}"/>
+    <input name="method" type="hidden" value="update"/>
     <input id="config-submit" type="submit" value="Update"/>
   </fieldset>
 </form>
@@ -42,6 +43,7 @@ repo:
 <form id="repo-delete-form" action="/api/repos/{{user}}?method=delete" method="POST">
     <fieldset>
         <input name="repo" type="hidden" value="{{name}}"/>
+        <input name="method" type="hidden" value="delete"/>
         <input id="repo-delete" type="submit" value="Delete"/>
     </fieldset>
 </form>

--- a/src/main/resources/dashboard/repo.hbs
+++ b/src/main/resources/dashboard/repo.hbs
@@ -35,7 +35,7 @@ repo:
       - download
 {{/if}}</textarea>
     <input name="repo" type="hidden" value="{{name}}"/>
-    <input name="method" type="hidden" value="update"/>
+    <input name="action" type="hidden" value="update"/>
     <input id="config-submit" type="submit" value="Update"/>
   </fieldset>
 </form>
@@ -43,7 +43,7 @@ repo:
 <form id="repo-delete-form" action="/api/repos/{{user}}?method=delete" method="POST">
     <fieldset>
         <input name="repo" type="hidden" value="{{name}}"/>
-        <input name="method" type="hidden" value="delete"/>
+        <input name="action" type="hidden" value="delete"/>
         <input id="repo-delete" type="submit" value="Delete"/>
     </fieldset>
 </form>

--- a/src/test/java/com/artipie/management/api/ApiRepoDeleteSliceTest.java
+++ b/src/test/java/com/artipie/management/api/ApiRepoDeleteSliceTest.java
@@ -47,10 +47,10 @@ final class ApiRepoDeleteSliceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"bin.yaml, bin.yml"})
+    @ValueSource(strings = {"bin.yaml", "bin.yml"})
     void deletesRepoConfig(final String config) {
         final String user = "bob";
-        new TestResource(config).saveTo(this.storage, new Key.From(user, config));
+        new TestResource("bin.yml").saveTo(this.storage, new Key.From(user, config));
         MatcherAssert.assertThat(
             "Repo config was not removed",
             new ApiRepoDeleteSlice(this.storage, new FakeConfigFile(this.storage)),


### PR DESCRIPTION
Part of artipie/artipie#321
Added slice `ApiRepoPostRtSlice` for routing post requests by parsing body content. This class will be used in artipie module. Test will be added in next PR